### PR TITLE
Remove license header

### DIFF
--- a/src/main/scala/energymonitor/rapl/sRAPL.scala
+++ b/src/main/scala/energymonitor/rapl/sRAPL.scala
@@ -1,33 +1,3 @@
-// MIT License
-
-// Copyright (c) 2017-Present Rui Pereira, Marco Couto, Francisco Ribeiro, Rui Rua, Jácome Cunha, João Paulo Fernandes, João Saraiva
-
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
-// Original source: https://github.com/WojciechMazur/Energy-Languages/blob/5ff4c3563d7437b98e00e895c9f414a10a74bc8c/Scala/sRAPL/sRAPL.scala
-
-/** This module converts the Scala RAPL code present in
-  * https://github.com/WojciechMazur/Energy-Languages to Scala 2.x. Scala 2.x is
-  * required to let sbt pick the appropriate Scala version for plugin
-  * compatibility.
-  */
-
 package energymonitor
 
 import cats.effect.{Resource, IO}


### PR DESCRIPTION
This PR removes the license header from the `sRAPL` file. Previously, I had copy-pasted the existing code (licensed under MIT license) and preserved the header, since I was expecting substantially to re-use the existing implementation. However, for purposes of the sbt plugin, I was able to remove all of it, so at this point all I've taken from it is instruction about how to use the jRAPL interfaces.

I'm not sure where to put license information for the jRAPL jar that I'm vendoring in `lib/jRAPL.jar`, but it's incorrect to include the former license header in `sRAPL.scala`