### PR TITLE
Post to GitHub after samples

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ lazy val Version = new {
   val catsEffect = "3.3.6"
   val catsScalacheck = "0.3.1"
   val circe = "0.14.1"
+  val github4s = "0.31.0"
+  val http4s = "0.23.10"
   val weaver = "0.7.9"
 }
 
@@ -31,8 +33,10 @@ inThisBuild(
       "io.chrisdavenport" %% "cats-scalacheck" % Version.catsScalacheck % Test,
       "com.disneystreaming" %% "weaver-cats" % Version.weaver % Test,
       "com.disneystreaming" %% "weaver-scalacheck" % Version.weaver % Test,
+      "com.47deg" %% "github4s" % Version.github4s,
       "io.circe" %% "circe-core" % Version.circe,
       "io.circe" %% "circe-parser" % Version.circe,
+      "org.http4s" %% "http4s-blaze-client" % Version.http4s,
       "org.scala-sbt" %% "collections" % sbtVersion.value,
       "org.scala-sbt" %% "core-macros" % sbtVersion.value,
       "org.scala-sbt" %% "main" % sbtVersion.value,

--- a/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
+++ b/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
@@ -65,12 +65,12 @@ object EnergyMonitorPlugin extends AutoPlugin {
     val duration = diff.getTimeElapsed()
     val totalJoules = samples.sum
     val watts = totalJoules / duration.getSeconds().toDouble
-    s"""
-  | During CI attempt ${attemptNumber}, this run consumed power from ${samples.size} CPU cores.
+    f"""
+  | During CI attempt ${attemptNumber}%d, this run consumed power from ${samples.size}%d CPU cores.
   |
-  | The total energy consumed in joules was ${totalJoules}.
+  | The total energy consumed in joules was ${totalJoules}%.2f.
   |
-  | In the sampling period, mean power consumption was ${watts} watts.
+  | In the sampling period, mean power consumption was ${watts}%.2f watts.
   """.trim().stripMargin
   }
 

--- a/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
+++ b/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
@@ -150,6 +150,7 @@ object EnergyMonitorPlugin extends AutoPlugin {
     energyMonitorDisableSampling := energyMonitorDisableSampling.value || false,
     energyMonitorPreSample := preSampleTask.value,
     energyMonitorPostSample := postSampleTask.value,
+    energyMonitorPostSampleGitHub := postSampleGitHubTask.value,
     energyMonitorOutputFile := energyMonitorOutputFile.value
   )
 

--- a/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
+++ b/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
@@ -50,9 +50,14 @@ object EnergyMonitorPlugin extends AutoPlugin {
 
   private def readPRNumberFromEnv: Option[Int] =
     sys.env.get("GITHUB_REF").flatMap { ref =>
-      "refs/pull//merge".r.findAllIn(ref).matchData.toList.headOption.map { m =>
-        m.group(1).toInt
-      }
+      "refs/pull/([0-9])+/merge".r
+        .findAllIn(ref)
+        .matchData
+        .toList
+        .headOption
+        .map { m =>
+          m.group(1).toInt
+        }
     }
 
   private def buildComment(diff: EnergyDiff, attemptNumber: Int): String = {

--- a/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
+++ b/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
@@ -157,6 +157,7 @@ object EnergyMonitorPlugin extends AutoPlugin {
   override lazy val buildSettings = Seq()
 
   override lazy val globalSettings = Seq(
-    energyMonitorOutputFile := "target/energy-sample"
+    energyMonitorOutputFile := "target/energy-sample",
+    energyMonitorDisableSampling := false
   )
 }

--- a/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
+++ b/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
@@ -66,7 +66,7 @@ object EnergyMonitorPlugin extends AutoPlugin {
     val totalJoules = samples.sum
     val watts = totalJoules / duration.getSeconds().toDouble
     s"""
-  | During CI attempt #${attemptNumber}, this run consumed power from ${samples.size} CPU cores.
+  | During CI attempt ${attemptNumber}, this run consumed power from ${samples.size} CPU cores.
   |
   | The total energy consumed in joules was ${totalJoules}.
   |

--- a/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
+++ b/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
@@ -103,7 +103,11 @@ object EnergyMonitorPlugin extends AutoPlugin {
       Option.empty[EnergyDiff]
     } else {
       postSample(Paths.get(energyMonitorOutputFile.value))
-        .map(Some(_))
+        .map({ diff =>
+          // logging unsafely here since otherwise there's nothing to do with the information
+          log.info(buildComment(diff, -1))
+          Some(diff)
+        })
         .unsafeRunSync()
     }
   }

--- a/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
+++ b/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
@@ -48,9 +48,9 @@ object EnergyMonitorPlugin extends AutoPlugin {
   val disabledSamplingMessage =
     "Sampling disabled, not attempting to collect energy consumption stats"
 
-  private def readPRNumberFromEnv: Option[Int] =
+  def readPRNumberFromEnv: Option[Int] =
     sys.env.get("GITHUB_REF").flatMap { ref =>
-      "refs/pull/([0-9])+/merge".r
+      "refs/pull/([0-9]+)/merge".r
         .findAllIn(ref)
         .matchData
         .toList

--- a/src/sbt-test/sbt-energymonitor/simple/build.sbt
+++ b/src/sbt-test/sbt-energymonitor/simple/build.sbt
@@ -1,4 +1,4 @@
 version := "0.1"
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.15"
 
 ThisBuild / energyMonitorDisableSampling := true

--- a/src/sbt-test/sbt-energymonitor/simple/test
+++ b/src/sbt-test/sbt-energymonitor/simple/test
@@ -1,3 +1,4 @@
 > compile
 > energyMonitorPreSample
 > energyMonitorPostSample
+> energyMonitorPostSampleGitHub


### PR DESCRIPTION
This PR adds another task that will attempt to post the energy consumption results to GitHub after sampling.

While this isn't actually feasible in CI in real life because of challenges discussed in https://github.com/47degrees/sbt-energymonitor/pull/6#issuecomment-1054567642, it's still part of the plan for technical implementation. This PR completes the technical implementation piece of the Click Up task.

The announcement post is the remaining piece, and I can explain limitations and "copy this JAR to _here_" steps as part of that.

You can see examples of the GitHub comments produced in https://github.com/jisantuc/droste-playground/pull/5