### PR TITLE
Add docs module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,3 +59,8 @@ enablePlugins(ScriptedPlugin)
 // set up 'scripted; sbt plugin for testing sbt plugins
 scriptedLaunchOpts ++=
   Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+
+lazy val documentation = project
+  .enablePlugins(MdocPlugin)
+  .settings(mdocOut := file("."))
+  .settings(publish / skip := true)


### PR DESCRIPTION
This PR adds a `documentation` module with the `MdocPlugin` enabled (`sbt-mdoc` is already in the plugins list). I think this is all that's required for the `ci-docs` task to succeed based on what's in the sbt-microsites build.sbt? 🤞🏻

Note: I didn't `skip ci` on this one because of the test failure on `main` -- previously the tests weren't _failing_, just logging some nice "ERROR read_msr(): pread error!" messages 🤔