### PR TITLE
Include missing alias

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ addCommandAlias(
   ";scalafmtCheckAll; scalafmtSbtCheck; test; publishLocal; scripted"
 )
 addCommandAlias("ci-publish", "github; ci-release")
+addCommandAlias("ci-docs", ";github; mdoc; headerCreateAll")
 
 inThisBuild(
   List(


### PR DESCRIPTION
This PR adds the `ci-docs` alias, which I missed in initial project setup. I ran it locally to verify that everything else is set up for it correctly and got the following diff:

```diff
diff --git a/LICENSE.md b/LICENSE.md
index 76b6d4e..0f33122 100644
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (C)  @YEAR_RANGE@ @COPYRIGHT_OWNER@
+   Copyright (C)  2022 47 Degrees Open Source <https://www.47deg.com>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
diff --git a/src/main/scala/energymonitor/EnergyMonitorPlugin.scala b/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
index c012aae..db1d051 100644
--- a/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
+++ b/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package energymonitor
 
 import cats.effect.IO
diff --git a/src/main/scala/energymonitor/rapl/implicits.scala b/src/main/scala/energymonitor/rapl/implicits.scala
index bd7d998..95cb7fd 100644
--- a/src/main/scala/energymonitor/rapl/implicits.scala
+++ b/src/main/scala/energymonitor/rapl/implicits.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package energymonitor.rapl
 
 import cats.Eq
diff --git a/src/main/scala/energymonitor/rapl/sRAPL.scala b/src/main/scala/energymonitor/rapl/sRAPL.scala
index b64ca96..5b503fa 100644
--- a/src/main/scala/energymonitor/rapl/sRAPL.scala
+++ b/src/main/scala/energymonitor/rapl/sRAPL.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package energymonitor
 
 import cats.MonadError
diff --git a/src/test/scala/energymonitor/EnergymonitorSpec.scala b/src/test/scala/energymonitor/EnergymonitorSpec.scala
index 88263a3..08abe48 100644
--- a/src/test/scala/energymonitor/EnergymonitorSpec.scala
+++ b/src/test/scala/energymonitor/EnergymonitorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package energymonitor
 
 import cats.effect.IO
```