### PR TITLE
Fix version setting and Watts calculation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 name := """sbt-energymonitor"""
-version := "0.1-SNAPSHOT"
 organization := "com.47deg"
 
 ThisBuild / githubOrganization := "47degrees"

--- a/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
+++ b/src/main/scala/energymonitor/EnergyMonitorPlugin.scala
@@ -80,7 +80,7 @@ object EnergyMonitorPlugin extends AutoPlugin {
     val samples = diff.getPrimitiveSample()
     val duration = diff.getTimeElapsed()
     val totalJoules = samples.sum
-    val watts = totalJoules / duration.getSeconds().toDouble
+    val watts = totalJoules / (duration.toMillis().toDouble / 1000)
     f"""
   | During CI attempt ${attemptNumber}%d, this run consumed power from ${samples.size}%d CPU cores.
   |


### PR DESCRIPTION
This PR:

- removes the explicit 0.1-SNAPSHOT version that the giter8 template I used set, since it was interfering with version inference in the release pipeline (e.g. the release for tag v0.1.2 [still wanted to release 0.1-SNAPSHOT](https://github.com/47degrees/sbt-energymonitor/runs/5397875623?check_suite_focus=true))
- corrects the denominator for calculating Watts. Watts are joules / second, but getSeconds was returning 0 seconds for sufficiently small durations, which caused printing `In the sampling period, mean power consumption was Infinity watts.` :scream: 

I think release should actually work in real life after this, since my version in `publishLocal` after removing the explicit version was `0.1.2+0-c22e6ab9+20220302-1416-SNAPSHOT`